### PR TITLE
Change blog description

### DIFF
--- a/about.md
+++ b/about.md
@@ -3,6 +3,6 @@ layout: page
 title: About
 permalink: /about/
 ---
-A blog about Research Software at Culhmam, UK.
+A blog with perspectives/tips from people working on research software for fusion.
 
 Created using [Github Pages](https://pages.github.com/) and [Jekyll](https://jekyllrb.com/).


### PR DESCRIPTION
This is a change to the description of the blog (in about.md), following suggestions from Alys, to indicate that it contains the perspective of individuals (and not an organisation).

Culham isn't mentioned in the description, because it is already mentioned in the blog name/title.  We could add "at Culham, UK" (or "_in_ Culham, UK"), if PR reviewers this would prefer that.

(I don't know why GitHub suggests that the last line of the file has changed.  I created the PR using the "edit" button in GitHub's web interface.)